### PR TITLE
TimeoutException should be handled

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -54,7 +54,7 @@ class Glances(object):
                     response = await client.get(
                         str(url), auth=(self.username, self.password)
                     )
-        except httpx.ConnectError:
+        except (httpx.ConnectError, httpx.TimeoutException):
             raise exceptions.GlancesApiConnectionError(f"Connection to {url} failed")
 
         if response.status_code == httpx.codes.UNAUTHORIZED:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from glances_api import Glances
+from glances_api import Glances, exceptions
 
 
 @pytest.mark.asyncio
@@ -18,6 +18,6 @@ async def test_timeout(httpx_mock: HTTPXMock):
 
     httpx_mock.add_callback(raise_timeout)
 
-    with pytest.raises(httpx.ReadTimeout):
+    with pytest.raises(exceptions.GlancesApiConnectionError):
         client = Glances()
         await client.get_metrics("mem")


### PR DESCRIPTION
I believe that the lack of support for TimeoutException may be the root cause of a few issues encountered since the migration to httpx (see https://github.com/home-assistant/core/issues/65727#issuecomment-1111489259)