### PR TITLE
Raise error for any not OK response code

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -61,22 +61,22 @@ class Glances:
             raise exceptions.GlancesApiAuthorizationError(
                 "Please check your credentials"
             )
-        if response.status_code == httpx.codes.BAD_REQUEST:
+            
+        if response.status_code != httpx.codes.OK:
             raise exceptions.GlancesApiNoDataAvailable(
                 f"endpoint: '{endpoint}' is not valid"
             )
-        if response.status_code == httpx.codes.OK:
-            try:
-                _LOGGER.debug(response.json())
-                if endpoint == "all":
-                    self.data = response.json()
-                elif endpoint == "pluginslist":
-                    self.plugins = response.json()
-            except TypeError:
-                _LOGGER.error("Can not load data from Glances")
-                raise exceptions.GlancesApiConnectionError(
-                    "Unable to get the data from Glances"
-                )
+        try:
+            _LOGGER.debug(response.json())
+            if endpoint == "all":
+                self.data = response.json()
+            elif endpoint == "pluginslist":
+                self.plugins = response.json()
+        except TypeError:
+            _LOGGER.error("Can not load data from Glances")
+            raise exceptions.GlancesApiConnectionError(
+                "Unable to get the data from Glances"
+            )
 
     async def get_metrics(self, element: str) -> None:
         """Get all the metrics for a monitored element."""


### PR DESCRIPTION
Some users reported that the glances integration is failing or not creating any sensors. It turned out that they have glances running in -s mode and not in -w mode. Doing so will return a 501 status_code when the get all data request is sent.
This PR ensures that we raise an error for any response status that is not 200.
Fixes issue: https://github.com/home-assistant/core/issues/70373  