### PR TITLE
Update 'containers` data key

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -144,9 +144,10 @@ class Glances:
                     "tx": round(network["tx"] / 1024, 1),
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
-        if "docker" in self.data and (data := self.data["docker"].get("containers")):
+        data = self.data.get("dockers") or self.data.get("containers")
+        if data and (containers_data := data.get("containers")):
             active_containers = [
-                container for container in data if container["Status"] == "running"
+                container for container in containers_data if container["Status"] == "running"
             ]
             sensor_data["docker"] = {"docker_active": len(active_containers)}
             cpu_use = 0.0

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -147,7 +147,9 @@ class Glances:
         data = self.data.get("dockers") or self.data.get("containers")
         if data and (containers_data := data.get("containers")):
             active_containers = [
-                container for container in containers_data if container["Status"] == "running"
+                container
+                for container in containers_data
+                if container["Status"] == "running"
             ]
             sensor_data["docker"] = {"docker_active": len(active_containers)}
             cpu_use = 0.0

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -37,7 +37,9 @@ RESPONSE = {
             "key": "disk_name",
         },
     ],
-    "docker": {
+    "containers": {
+        "version": {},
+        "version_podman": {},
         "containers": [
             {
                 "key": "name",

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -71,7 +71,7 @@ RESPONSE = {
                 },
                 "memory_usage": 50126848,
             },
-        ]
+        ],
     },
     "fs": [
         {

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -291,8 +291,8 @@ async def test_ha_sensor_data_with_incomplete_container_information(
     del TEST_RESPONSE["containers"]["containers"][1]["cpu"]["total"]
 
     TEST_HA_SENSOR_DATA = HA_SENSOR_DATA
-    TEST_HA_SENSOR_DATA["containers"]["docker_memory_use"] = 0
-    TEST_HA_SENSOR_DATA["containers"]["docker_cpu_use"] = 0
+    TEST_HA_SENSOR_DATA["docker"]["docker_memory_use"] = 0
+    TEST_HA_SENSOR_DATA["docker"]["docker_cpu_use"] = 0
 
     httpx_mock.add_response(json=TEST_RESPONSE)
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -285,14 +285,14 @@ async def test_ha_sensor_data_with_incomplete_container_information(
 ):
     """Test the return value for ha sensors when container memory and cpu data is not exposed by glances."""
     TEST_RESPONSE = RESPONSE
-    del TEST_RESPONSE["docker"]["containers"][0]["memory"]["usage"]
-    del TEST_RESPONSE["docker"]["containers"][0]["cpu"]["total"]
-    del TEST_RESPONSE["docker"]["containers"][1]["memory"]["usage"]
-    del TEST_RESPONSE["docker"]["containers"][1]["cpu"]["total"]
+    del TEST_RESPONSE["containers"]["containers"][0]["memory"]["usage"]
+    del TEST_RESPONSE["containers"]["containers"][0]["cpu"]["total"]
+    del TEST_RESPONSE["containers"]["containers"][1]["memory"]["usage"]
+    del TEST_RESPONSE["containers"]["containers"][1]["cpu"]["total"]
 
     TEST_HA_SENSOR_DATA = HA_SENSOR_DATA
-    TEST_HA_SENSOR_DATA["docker"]["docker_memory_use"] = 0
-    TEST_HA_SENSOR_DATA["docker"]["docker_cpu_use"] = 0
+    TEST_HA_SENSOR_DATA["containers"]["docker_memory_use"] = 0
+    TEST_HA_SENSOR_DATA["containers"]["docker_cpu_use"] = 0
 
     httpx_mock.add_response(json=TEST_RESPONSE)
 


### PR DESCRIPTION
I noticed that `dockers` key is not showing in the latest glances api response. It has been replaced by `containers`. I updated the code to check for both keys.