### PR TITLE
Add percpu data

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -138,7 +138,7 @@ class Glances:
         if data := self.data.get("percpu"):
             sensor_data["percpu"] = {}
             for cpu in data:
-                sensor_data["percpu"][cpu["cpu_number"]] = {
+                sensor_data["percpu"][str(cpu["cpu_number"])] = {
                     "cpu_use_percent": cpu["total"]
                 }
         if networks := self.data.get("network"):

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -135,6 +135,12 @@ class Glances:
             }
         if data := self.data.get("quicklook"):
             sensor_data["cpu"] = {"cpu_use_percent": data["cpu"]}
+        if data := self.data.get("percpu"):
+            sensor_data["percpu"] = {}
+            for cpu in data:
+                sensor_data["percpu"][cpu["cpu_number"]] = {
+                    "cpu_use_percent": cpu["total"]
+                }
         if networks := self.data.get("network"):
             sensor_data["network"] = {}
             for network in networks:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -26,6 +26,38 @@ RESPONSE = {
         "nice": 0.0,
         "iowait": 0.6,
     },
+    "percpu": [
+        {
+            "key": "cpu_number",
+            "cpu_number": 0,
+            "total": 22.1,
+            "user": 7.6,
+            "system": 12.4,
+            "idle": 77.9,
+            "nice": 0.0,
+            "iowait": 0.2,
+            "irq": 0.0,
+            "softirq": 1.8,
+            "steal": 0.0,
+            "guest": 0.0,
+            "guest_nice": 0.0,
+        },
+        {
+            "key": "cpu_number",
+            "cpu_number": 1,
+            "total": 17.2,
+            "user": 8.7,
+            "system": 7.8,
+            "idle": 82.8,
+            "nice": 0.0,
+            "iowait": 0.4,
+            "irq": 0.0,
+            "softirq": 0.3,
+            "steal": 0.0,
+            "guest": 0.0,
+            "guest_nice": 0.0,
+        },
+    ],
     "diskio": [
         {
             "time_since_update": 1,
@@ -228,6 +260,7 @@ HA_SENSOR_DATA = {
     },
     "docker": {"docker_active": 2, "docker_cpu_use": 77.2, "docker_memory_use": 1149.6},
     "uptime": "3 days, 10:25:20",
+    "percpu": {"0": "22.1", "1": "17.2"},
 }
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -260,7 +260,7 @@ HA_SENSOR_DATA = {
     },
     "docker": {"docker_active": 2, "docker_cpu_use": 77.2, "docker_memory_use": 1149.6},
     "uptime": "3 days, 10:25:20",
-    "percpu": {"0": "22.1", "1": "17.2"},
+    "percpu": {"0": {"cpu_use_percent": 22.1}, "1": {"cpu_use_percent": 17.2}},
 }
 
 


### PR DESCRIPTION
Add `percpu` data. Will require adding new key to home-assistant/core once merged.