### PR TITLE
Fix network RX and TX for Home Assistant (bytes/s)

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -156,8 +156,8 @@ class Glances:
                 time_since_update = network["time_since_update"]
                 sensor_data["network"][network["interface_name"]] = {
                     "is_up": network.get("is_up"),
-                    "rx": round(network["rx"] / time_since_update * 8, 1),
-                    "tx": round(network["tx"] / time_since_update * 8 , 1),
+                    "rx": round(network["rx"] / time_since_update * 8),
+                    "tx": round(network["tx"] / time_since_update * 8),
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
         data = self.data.get("dockers") or self.data.get("containers")

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -156,8 +156,8 @@ class Glances:
                 time_since_update = network["time_since_update"]
                 sensor_data["network"][network["interface_name"]] = {
                     "is_up": network.get("is_up"),
-                    "rx": round(network["rx"] / time_since_update * 8),
-                    "tx": round(network["tx"] / time_since_update * 8),
+                    "rx": round(network["rx"] / time_since_update),
+                    "tx": round(network["tx"] / time_since_update),
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
         data = self.data.get("dockers") or self.data.get("containers")

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -153,10 +153,11 @@ class Glances:
         if networks := self.data.get("network"):
             sensor_data["network"] = {}
             for network in networks:
+                time_since_update = network["time_since_update"]
                 sensor_data["network"][network["interface_name"]] = {
                     "is_up": network.get("is_up"),
-                    "rx": round(network["rx"] / 1024, 1),
-                    "tx": round(network["tx"] / 1024, 1),
+                    "rx": round(network["rx"] / time_since_update * 8, 1),
+                    "tx": round(network["tx"] / time_since_update * 8 , 1),
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
         data = self.data.get("dockers") or self.data.get("containers")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -256,10 +256,10 @@ HA_SENSOR_DATA: dict[str, Any] = {
         "memory_free": 2745.0,
     },
     "network": {
-        "lo": {"is_up": True, "rx": 11.6, "tx": 11.6, "speed": 0.0},
+        "lo": {"is_up": True, "rx": 61170.9, "tx": 61170.9, "speed": 0.0},
         "bond0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 64.0},
         "dummy0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
-        "eth0": {"is_up": True, "rx": 6.0, "tx": 9.1, "speed": 9.8},
+        "eth0": {"is_up": True, "rx": 31622.6, "tx": 47964.0, "speed": 9.8},
         "tunl0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
         "sit0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
     },

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -256,10 +256,10 @@ HA_SENSOR_DATA: dict[str, Any] = {
         "memory_free": 2745.0,
     },
     "network": {
-        "lo": {"is_up": True, "rx": 61171, "tx": 61171, "speed": 0.0},
+        "lo": {"is_up": True, "rx": 7646, "tx": 7646, "speed": 0.0},
         "bond0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 64.0},
         "dummy0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
-        "eth0": {"is_up": True, "rx": 31623, "tx": 47964, "speed": 9.8},
+        "eth0": {"is_up": True, "rx": 3953, "tx": 5995, "speed": 9.8},
         "tunl0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
         "sit0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
     },

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -256,10 +256,10 @@ HA_SENSOR_DATA: dict[str, Any] = {
         "memory_free": 2745.0,
     },
     "network": {
-        "lo": {"is_up": True, "rx": 61170.9, "tx": 61170.9, "speed": 0.0},
+        "lo": {"is_up": True, "rx": 61171, "tx": 61171, "speed": 0.0},
         "bond0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 64.0},
         "dummy0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
-        "eth0": {"is_up": True, "rx": 31622.6, "tx": 47964.0, "speed": 9.8},
+        "eth0": {"is_up": True, "rx": 31623, "tx": 47964, "speed": 9.8},
         "tunl0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
         "sit0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
     },


### PR DESCRIPTION
The aim of this Pull Request is to have correct network data sent to Home Assistant.
It is a first step before integrating network sensors into HA.

The correct computation of RX and TX values is described here by the Glances author :
https://github.com/nicolargo/glances/issues/1406#issuecomment-456965558
https://github.com/nicolargo/glances/issues/1704#issuecomment-673510389

In Bytes/second :
`rx in Bps = rx / time_since_update`
`tx in Bps = tx / time_since_update`

Linked PR in HA:
https://github.com/home-assistant/core/pull/114546