### PR TITLE
Add diskio sensors for Home Assistant (in bytes/second)

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -1,4 +1,5 @@
 """Client to interact with the Glances API."""
+
 from __future__ import annotations
 
 import logging
@@ -188,5 +189,13 @@ class Glances:
                     "mem": sensor["mem"],
                     "proc": sensor["proc"],
                     "fan_speed": sensor["fan_speed"] if "fan_speed" in sensor else 0,
+                }
+        if data := self.data.get("diskio"):
+            sensor_data["diskio"] = {}
+            for disk in data:
+                time_since_update = disk["time_since_update"]
+                sensor_data["diskio"][disk["disk_name"]] = {
+                    "read": round(disk["read_bytes"] / time_since_update),
+                    "write": round(disk["write_bytes"] / time_since_update),
                 }
         return sensor_data

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -299,6 +299,7 @@ HA_SENSOR_DATA: dict[str, Any] = {
     "diskio": {
         "nvme0n1": {"read": 184320, "write": 23863296},
         "sda": {"read": 3859, "write": 25954},
+    },
     "gpu": {
         "NVIDIA GeForce RTX 4080 (GPU 0)": {
             "mem": 13.333489176233513,

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,4 +1,5 @@
 """Test the interaction with the Glances API."""
+
 from typing import Any
 
 import pytest
@@ -69,6 +70,15 @@ RESPONSE: dict[str, Any] = {
             "write_count": 466,
             "read_bytes": 184320,
             "write_bytes": 23863296,
+            "key": "disk_name",
+        },
+        {
+            "time_since_update": 142.23511338233948,
+            "disk_name": "sda",
+            "read_count": 34,
+            "write_count": 254,
+            "read_bytes": 548864,
+            "write_bytes": 3691520,
             "key": "disk_name",
         },
     ],
@@ -266,6 +276,10 @@ HA_SENSOR_DATA: dict[str, Any] = {
     "docker": {"docker_active": 2, "docker_cpu_use": 77.2, "docker_memory_use": 1149.6},
     "uptime": "3 days, 10:25:20",
     "percpu": {"0": {"cpu_use_percent": 22.1}, "1": {"cpu_use_percent": 17.2}},
+    "diskio": {
+        "nvme0n1": {"read": 184320, "write": 23863296},
+        "sda": {"read": 3859, "write": 25954},
+    },
 }
 
 


### PR DESCRIPTION
The aim of this PR is to add diskio sensors for Hone Assistant.
The unit is in bytes/second :
```
read = read_bytes / time_since_update
write = write_bytes / time_since_update
```
The unit test includes a sample with two disks.
Once the library is released I will create a PR in Home Assistant to use these new sensors. 

[Glances documentation](https://glances.readthedocs.io/en/latest/api.html?highlight=diskio#get-diskio)

Note: 
diskio can be configured server side in `glances.conf` to limit the number of disks, or it can also be disabled completely with 
```
[diskio]
disable=True
```
 