### PR TITLE
Add support for Glances v4 network sensors

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -155,10 +155,18 @@ class Glances:
             sensor_data["network"] = {}
             for network in networks:
                 time_since_update = network["time_since_update"]
+                # New name of network sensors in Glances v4
+                rx = network.get("bytes_recv_rate_per_sec")
+                tx = network.get("bytes_sent_rate_per_sec")
+                # Compatibility with Glances v3
+                if rx is None and (rx_bytes := network.get("rx")) is not None:
+                    rx = round(rx_bytes / time_since_update)
+                if tx is None and (tx_bytes := network.get("tx")) is not None:
+                    tx = round(tx_bytes / time_since_update)
                 sensor_data["network"][network["interface_name"]] = {
                     "is_up": network.get("is_up"),
-                    "rx": round(network["rx"] / time_since_update),
-                    "tx": round(network["tx"] / time_since_update),
+                    "rx": rx,
+                    "tx": tx,
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
         data = self.data.get("dockers") or self.data.get("containers")


### PR DESCRIPTION
This PR adds support for Glances v4 network sensors.
The new format of network sensors is described here :
https://github.com/nicolargo/glances/blob/develop/docs/api.rst#get-network

I haven't seen any other breaking changes in Glances v4 API  (aside from the url obviously):
https://github.com/nicolargo/glances/compare/v3.4.0.5...v4.0.4?short_path=0ee295c

Initial testing in Home Assistant is good with this PR + change of API version in HA.
I'll submit a PR in HA once this PR is validated and a new version released.