### PR TITLE
Add/improve support for Glances v4 container & network format and improve v4 unit tests

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -172,19 +172,20 @@ class Glances:
                 }
         containers_data = None
         if self.version >= 4:
-            #Glances v4 provides a list of containers
+            # Glances v4 provides a list of containers
             containers_data = self.data.get("containers")
         else:
-            #Glances v3 and earlier provide a dict, with containers inside a list in this dict
-            #Key is "dockers" in 3.3 and before, and "containers" in 3.4
+            # Glances v3 and earlier provide a dict, with containers inside a list in this dict
+            # Key is "dockers" in 3.3 and before, and "containers" in 3.4
             data = self.data.get("dockers") or self.data.get("containers")
             containers_data = data.get("containers") if data else None
         if containers_data:
             active_containers = [
                 container
                 for container in containers_data
-                #"status" since Glance v4, "Status" in v3 and earlier
-                if container.get("status") == "running" or container.get("Status") == "running"
+                # "status" since Glance v4, "Status" in v3 and earlier
+                if container.get("status") == "running"
+                or container.get("Status") == "running"
             ]
             sensor_data["docker"] = {"docker_active": len(active_containers)}
             cpu_use = 0.0

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -155,15 +155,17 @@ class Glances:
         if networks := self.data.get("network"):
             sensor_data["network"] = {}
             for network in networks:
-                time_since_update = network["time_since_update"]
-                # New name of network sensors in Glances v4
-                rx = network.get("bytes_recv_rate_per_sec")
-                tx = network.get("bytes_sent_rate_per_sec")
-                # Compatibility with Glances v3
-                if rx is None and (rx_bytes := network.get("rx")) is not None:
-                    rx = round(rx_bytes / time_since_update)
-                if tx is None and (tx_bytes := network.get("tx")) is not None:
-                    tx = round(tx_bytes / time_since_update)
+                rx = tx = None
+                if self.version <= 3:
+                    time_since_update = network["time_since_update"]
+                    if (rx_bytes := network.get("rx")) is not None:
+                        rx = round(rx_bytes / time_since_update)
+                    if (tx_bytes := network.get("tx")) is not None:
+                        tx = round(tx_bytes / time_since_update)
+                else:
+                    # New network sensors in Glances v4
+                    rx = network.get("bytes_recv_rate_per_sec")
+                    tx = network.get("bytes_sent_rate_per_sec")
                 sensor_data["network"][network["interface_name"]] = {
                     "is_up": network.get("is_up"),
                     "rx": rx,

--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -171,14 +171,14 @@ class Glances:
                     "speed": round(network["speed"] / 1024**3, 1),
                 }
         containers_data = None
-        if self.version >= 4:
-            # Glances v4 provides a list of containers
-            containers_data = self.data.get("containers")
-        else:
+        if self.version <= 3:
             # Glances v3 and earlier provide a dict, with containers inside a list in this dict
             # Key is "dockers" in 3.3 and before, and "containers" in 3.4
             data = self.data.get("dockers") or self.data.get("containers")
             containers_data = data.get("containers") if data else None
+        else:
+            # Glances v4 provides a list of containers
+            containers_data = self.data.get("containers")
         if containers_data:
             active_containers = [
                 container


### PR DESCRIPTION
This PR adds support for the Glances v4 container format change, while retaining compatibility with earlier versions of HA.
=> Fixes issue #41 

The PR also addresses another issue in Glances v4, where Glances sends an incomplete network sensor when the module is disabled. The code was reworked to be more robust when Glances sends incomplete data.

Finally the PR adds dedicated unit tests for v4 data (parametrized test for get_ha_sensor_data).

Related HA issue : https://github.com/home-assistant/core/issues/118632
Related Glances issue : https://github.com/nicolargo/glances/issues/2815

As there are now 3 different formats of API for the containers, I have opted for a test on the Glances version rather than looking for the various possibilities.

To sum up the formats :
- 3.3 and before: section is called "dockers", data provided in a dict with an embedded list under the key "containers"
- 3.4: section is called "containers", data provided in a dict with an embedded list under the key "containers"
- 4.0: section is called "containers", data provided in a list