### PR TITLE
Add more CPU load sensors

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -134,8 +134,9 @@ class Glances:
             }
         if data := self.data.get("load"):
             sensor_data["load"] = {
-                "processor_load": data.get("min15")
-                or self.data["cpu"]["total"]  # to be checked
+                "processor_load": data.get("min15"),
+                "processor_load_1m": data.get("min1"),
+                "processor_load_5m": data.get("min5"),
             }
         if data := self.data.get("processcount"):
             sensor_data["processcount"] = {


### PR DESCRIPTION
Add sensors for 5 and 1 minute CPU load


```
"load": {
        "processor_load": 0.48486328125,
        "processor_load_1m": 0.66162109375,
        "processor_load_5m": 0.5546875
    }
```
Also `self.data["cpu"]["total"] ` return CPU usage in percent like `cpu_use_percent` which is different thing