### PR TITLE
Healthy status not taken into account in the containers count #50

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -188,8 +188,11 @@ class Glances:
                 container
                 for container in containers_data
                 # "status" since Glance v4, "Status" in v3 and earlier
+                # "healthy" status added to Glances 4.5 (see issue #50)
                 if container.get("status") == "running"
                 or container.get("Status") == "running"
+                or container.get("status") == "healthy"
+                or container.get("Status") == "healthy"
             ]
             sensor_data["docker"] = {"docker_active": len(active_containers)}
             cpu_use = 0.0


### PR DESCRIPTION
Correct issue #50 by taken into account the new field value (healthy) for containers status.

Will correct the issues:
- https://github.com/home-assistant/core/issues/163574
- https://github.com/nicolargo/glances/issues/3433 
