### PR TITLE
Expose total disk size to home assistant

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -112,6 +112,7 @@ class Glances:
                 sensor_data["fs"][disk["mnt_point"]] = {
                     "disk_use": round(disk["used"] / 1024**3, 1),
                     "disk_use_percent": disk["percent"],
+                    "disk_size": round(disk["size"] / 1024**3, 1),
                     "disk_free": round(disk_free / 1024**3, 1),
                 }
         if data := self.data.get("sensors"):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -276,8 +276,8 @@ RESPONSE: dict[str, Any] = {
 
 HA_SENSOR_DATA: dict[str, Any] = {
     "fs": {
-        "/ssl": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5},
-        "/media": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5},
+        "/ssl": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5, "disk_size": 476.2},
+        "/media": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5, "disk_size": 476.2},
     },
     "sensors": {"cpu_thermal 1": {"temperature_core": 59}},
     "mem": {


### PR DESCRIPTION
This PR adds total disk size to the home assistant data. Use case is a long-term storage graph for a btrfs array, where the total fs size may change as disks are added and removed. I'd like to graph the fs usage with the fs total size rather than using the percentage used. This means that if the total size changes it can be represented more cleanly on the graph by showing the GiB available has grown.

Draft PR for home-assistant: https://github.com/home-assistant/core/pull/168131