### PR TITLE
Add all containers on docker host and amps returned text  to sensor_data

### DIFF
--- a/glances_api/__init__.py
+++ b/glances_api/__init__.py
@@ -211,6 +211,26 @@ class Glances:
                         container["memory"].get("usage", 0) / 1024**2, 1
                     ),
                 }
+            container_list = []
+            for container in containers_data:
+                container_dict = {}
+                if container.get("uptime") is None:
+                    uptime_txt = "None"
+                else:
+                    uptime_txt = container.get("uptime")
+                container_dict = {
+                    "n" : container["name"],
+                    "c": round(container["cpu"].get("total", 0), 1),
+                    "m": round(container["memory"].get("usage", 0) / 1024**2, 1),
+                    "u": uptime_txt,
+                    "s": container.get("status"),
+                    "i": container.get("id")[:8],
+                    "e": container.get("engine"),
+                }
+                container_list.append(json.dumps(container_dict))
+            containersjson = json.dumps(container_list)
+            sensor_data["containers"] = {"containerslist": containersjson}
+            
         if data := self.data.get("raid"):
             sensor_data["raid"] = data
         if data := self.data.get("uptime"):
@@ -232,4 +252,22 @@ class Glances:
                     "read": round(disk["read_bytes"] / time_since_update),
                     "write": round(disk["write_bytes"] / time_since_update),
                 }
+        if data := self.data.get("amps"):
+            sensor_data["amps"] = {}
+            for amps in data:
+                if amps["result"] is None:
+                    rescount = 0
+                    restext = "None"
+                else:
+                    rescount = re.findall("^\d+",amps["result"])[0]
+                    restext = amps["result"]
+                sensor_data["amps"][amps["name"]] = {
+                    "result":restext,
+                    # "count": amps["count"],
+                    # "countmin": amps["countmin"],
+                    # "countmax": amps["countmax"],
+                    # "regex": amps["regex"],
+                    "resultcount": rescount
+                }
+        
         return sensor_data


### PR DESCRIPTION
I run a amps script to get the number of packages that need updating through apt.

It also lists all containers on my docker host and gathers all of them with cpu, memory, uptime, status and dockerID into a table so I can parse the list of docker containers and show on a dashboard card as a table. The Glances custom component needs updating to retrieve the extra data from the API, and I will submit a pull request for this soon.

Then in HA on a markdown card, I use the following to display the list of containers within a table. 

type: markdown
content: >
  {% set e_list = state_attr('sensor.localhost_containerslist',
  'ContainerInfo')  %}
  <table style="width:100%"> <tr> <th style="width:10%">ID</th> <th
  style="width:30%">Name</th> <th style="width:20%">Status</th> <th
  style="width:10%">Cpu</th> <th style="width:10%">Memory</th> <th
  style="width:20%">Uptime</th> </tr> {% set e_list_mod = e_list |
  replace("\\","") %} {% set e_list_mod = e_list_mod | replace("\"{","{") %} {%
  set e_list_mod = e_list_mod | replace("}\"","}")  %} {% set e_list_json =
  e_list_mod | from_json %} {% for x in e_list_json %} <tr> <td>{{x.i[:4]}}</td>
  <td>{{x.n}}</td> <td>{{x.s}}</td> <td>{{x.c}}</td> <td>{{x.m}}</td>
  <td>{{x.u}}</td> </tr> {% endfor %} </table>